### PR TITLE
Fix to comparing revisions

### DIFF
--- a/Support/app/controllers/diff_controller.rb
+++ b/Support/app/controllers/diff_controller.rb
@@ -42,7 +42,7 @@ class DiffController < ApplicationController
   end
   
   def compare_revisions
-    file_paths = git.paths.first
+    file_paths = git.paths
     if file_paths.length > 1
       base = git.nca(file_paths)
     else 


### PR DESCRIPTION
Hello,

There is a bug in the bundle which keeps comparing revisions from working. It looks like the offending code has been there since 2008 so not sure how it ever worked, but it did used to. Maybe the path wasn't being followed.

Hope this helps.

-Lukas
